### PR TITLE
Feature/fetch from variable video issue #13

### DIFF
--- a/functions/chat.go
+++ b/functions/chat.go
@@ -121,6 +121,10 @@ func chatWatcher(w http.ResponseWriter, r *http.Request) {
 	// Because the chat of the target of acquisition is focused on the live video,
 	// and chatting to other videos during the live is not necessary for the use case.
 	if len(liveVideos) > 0 {
+		slog.Info(
+			"Live video found",
+			slog.Group("liveVideo", "chatId", liveVideos[0].ChatID),
+		)
 		// TODO: Implement the process for live videos
 
 		// Other videos are skipped

--- a/functions/chat.go
+++ b/functions/chat.go
@@ -138,6 +138,9 @@ func chatWatcher(w http.ResponseWriter, r *http.Request) {
 		panic(fmt.Sprintf("Failed to unmarshal static target: %v", err))
 	}
 
+	// Combine the upcoming videos and the static target as fetching targets
+	targetVideos := append(upcomingVideos, staticTarget)
+
 	// Fetch chats from StaticTarget
 	staticChats, err := fetchChatsByChatID(ctx, ytSvc, staticTarget, 0)
 	if err != nil {

--- a/functions/chat.go
+++ b/functions/chat.go
@@ -100,6 +100,23 @@ func chatWatcher(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Separate processing by status: live or upcoming
+	var liveVideos []VideoInfo
+	var upcomingVideos []VideoInfo
+	for _, video := range targetVideos {
+		if video.Status == "live" {
+			liveVideos = append(liveVideos, VideoInfo{
+				ChatID:   video.ChatID,
+				SourceID: video.SourceID,
+			})
+		} else {
+			upcomingVideos = append(upcomingVideos, VideoInfo{
+				ChatID:   video.ChatID,
+				SourceID: video.SourceID,
+			})
+		}
+	}
+
 	// load info of video from environment variables
 	staticEnv := os.Getenv("STATIC_TARGET")
 	var staticTarget VideoInfo

--- a/functions/chat.go
+++ b/functions/chat.go
@@ -117,6 +117,17 @@ func chatWatcher(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// If there is a live video, process only that video and skip processing of other videos.
+	// Because the chat of the target of acquisition is focused on the live video,
+	// and chatting to other videos during the live is not necessary for the use case.
+	if len(liveVideos) > 0 {
+		// TODO: Implement the process for live videos
+
+		// Other videos are skipped
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	// load info of video from environment variables
 	staticEnv := os.Getenv("STATIC_TARGET")
 	var staticTarget VideoInfo

--- a/functions/chat.go
+++ b/functions/chat.go
@@ -89,6 +89,17 @@ func chatWatcher(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Get info of videos with the target status
+	targetStatus := []string{"live", "upcoming"}
+	targetVideos, err := getVideoRecordByStatus(ctx, dbClient, targetStatus)
+	if err != nil {
+		slog.Error("Failed to get video records",
+			slog.Group("database", "error", err),
+		)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	// load info of video from environment variables
 	staticEnv := os.Getenv("STATIC_TARGET")
 	var staticTarget VideoInfo

--- a/functions/chat.go
+++ b/functions/chat.go
@@ -91,7 +91,7 @@ func chatWatcher(w http.ResponseWriter, r *http.Request) {
 
 	// Get info of videos with the target status
 	targetStatus := []string{"live", "upcoming"}
-	targetVideos, err := getVideoRecordByStatus(ctx, dbClient, targetStatus)
+	videoRecords, err := getVideoRecordByStatus(ctx, dbClient, targetStatus)
 	if err != nil {
 		slog.Error("Failed to get video records",
 			slog.Group("database", "error", err),
@@ -103,7 +103,7 @@ func chatWatcher(w http.ResponseWriter, r *http.Request) {
 	// Separate processing by status: live or upcoming
 	var liveVideos []VideoInfo
 	var upcomingVideos []VideoInfo
-	for _, video := range targetVideos {
+	for _, video := range videoRecords {
 		if video.Status == "live" {
 			liveVideos = append(liveVideos, VideoInfo{
 				ChatID:   video.ChatID,

--- a/functions/database.go
+++ b/functions/database.go
@@ -14,6 +14,17 @@ func NewDBClient(dsn string) (*bun.DB, error) {
 	return db, nil
 }
 
+func getVideoRecordByStatus(ctx context.Context, db *bun.DB, status []string) ([]VideoRecord, error) {
+	records := make([]VideoRecord, 0)
+	err := db.NewSelect().Model(&records).Where("status IN (?)", status).Column("source_id", "status", "chat_id").Scan(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return records, nil
+
+}
+
 func getLastPublishedAtOfRecord(ctx context.Context, db *bun.DB) (int64, error) {
 	// Get the last recorded chat
 	record := new(ChatRecord)

--- a/functions/model.go
+++ b/functions/model.go
@@ -32,6 +32,5 @@ type VideoRecord struct {
 
 type VideoInfo struct {
 	SourceID string `json:"sourceId"`
-	Status   string `json:"status"`
 	ChatID   string `json:"chatId"`
 }

--- a/functions/model.go
+++ b/functions/model.go
@@ -21,6 +21,15 @@ type ChatRecord struct {
 	PublishedAt time.Time `bun:",type:timestamp"`
 }
 
+type VideoRecord struct {
+	bun.BaseModel `bun:"table:videos"`
+
+	SourceID  string    `bun:",type:varchar(255)"`
+	Status    string    `bun:",type:varchar(255)"`
+	ChatID    string    `bun:",type:varchar(255)"`
+	UpdatedAt time.Time `bun:",type:timestamp"`
+}
+
 type VideoInfo struct {
 	SourceID string `json:"sourceId"`
 	Status   string `json:"status"`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ステータス（ライブまたは今後の予定）に基づいてビデオを処理する機能を追加しました。
	- ライブビデオと今後のビデオを別々に扱うロジックを導入しました。
	- ライブビデオが存在する場合、他のビデオの処理をスキップするように実装しました。
	- 今後のビデオを静的ターゲットと組み合わせてフェッチターゲットを改善しました。
	- YouTube APIからのチャットフェッチングロジックを複数のターゲットビデオを取り入れて強化しました。
	- チャットのフィルタリングを公開日と作者によって効率化しました。
	- チャットデータの改訂に基づいて、チャットの変換と挿入プロセスを更新しました。

- **バグ修正**
	- YouTube APIからチャットをフェッチする際のエラーハンドリングとレスポンスを改善しました。

- **データベース**
	- ステータス基準に基づいてビデオレコードを取得する新しい関数`getVideoRecordByStatus`を追加しました。

- **データモデルの変更**
	- 新しい`VideoRecord`構造体を追加し、`SourceID`、`Status`、`ChatID`、`UpdatedAt`フィールドを含めました。`VideoInfo`構造体から`Status`フィールドを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->